### PR TITLE
Transition to using an explicit config mechanism, including @docnote decorator

### DIFF
--- a/.github/workflows/on_pr-run_cicd.yaml
+++ b/.github/workflows/on_pr-run_cicd.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Run pyright
         shell: bash
         run: |
-          pyright --pythonpath=.venv/bin/python --verbose
+          pyright --pythonpath=.venv/bin/python
 
   unittests:
     name: Pytest -- unittests

--- a/README.clc
+++ b/README.clc
@@ -6,31 +6,56 @@ defining documentation notes within python source code as values passed via
 ``Annotated``.
 
 On its own, this isn't very useful, but in combination with a docs-generation
-library that is aware of them (for example, ``clcdocs``), it can be very
+library that is aware of them (for example, ``docnote_build``), it can be very
 powerful.
 
 This is distributed as a separate package because it must, by definition, be
-included as a production dependency in any packages that make use of it.
+included as a production dependency in any packages that make use of it, and
+we want to minimize the required redistributable footprint.
 
-The API here is very, very bare-bones.
+The API here is very, very bare-bones, and **purely declarative.** Any and all
+actual functionality, including things like performing the actual enforcement
+checks you request in your ``DocnoteConfig``s, **must be done by your docs
+generation library!** This should ideally run as part of your CI/CD suite,
+or a githook, etc.
 
-> Intended usage
+> Basic intended usage
 __embed__: 'code/python'
     from typing import Annotated
 
-    from docnote import ClcNote
-    from docnote import DocNote
-    from docnote import MarkupLang
+    import docnote
+    from docnote import Note
+    from docnote import DocnoteConfig
+    from docnote import docnote
+
+    # Optional -- allows you to set module-level config
+    DOCNOTE_CONFIG = DocnoteConfig(
+        enforce_known_lang=True,
+        markup_lang=doctnote.MarkupLang.CLEANCOPY)
 
     # Note that the actual annotation for this is stored in the type hints for
     # the module object, not on MY_MODULE_CONSTANT itself!
     MY_MODULE_CONSTANT: Annotated[
         int,
-        DocNote('My own special module constant', lang=MarkupLang.MARKDOWN)
+        Note('My own special module constant')
     ] = 24
-
-    # Cleancopy has a prebuilt wrapper, making it a bit cleaner
-    MY_OTHER_MODULE_CONSTANT: Annotated[
+    # Notes can have their own dedicated configs
+    MY_OTHER_CONSTANT: Annotated[
         int,
-        ClcNote('Yet another module costant')
+        Note('My other module constant', config=DocnoteConfig())
     ] = 42
+
+    # The @docnote decorator allows you to configure settings on a per-object
+    # basis (configs can also be attached via ``Annotated``!)
+    @docnote(DocnoteConfig(include_in_docs=True))
+    def _included_in_docs_despite_underscore():
+        """By default / convention, docs generators will skip names that
+        start with a single underscore (or ``__mangled`` names). With
+        ``include_in_docs=True`` set in the attached config, this
+        will be included in the generated docs, despite the leading
+        underscore.
+
+        Note that the opposite works too, if you want to exclude an
+        otherwise public member from appearance in the docs.
+        """
+        ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,7 @@ dynamic = ["version"]
 requires-python = ">=3.12.0"
 readme = "README.md"
 
-dependencies = [
-]
+dependencies = []
 
 [dependency-groups]
 test = [
@@ -19,7 +18,6 @@ lint = [
 ]
 
 repl = [
-    "ipython >= 8.8.0",
     "wat-inspector >= 0.3.2"
 ]
 
@@ -47,8 +45,10 @@ cache_dir = '/tmp/pytest_cache'
 python_files = "*.test.py"
 
 [tool.ruff]
-dummy-variable-rgx = "^_{0,1}$"
 line-length = 79
+
+[tool.ruff.lint]
+dummy-variable-rgx = "^_{1,2}$"
 select = [
     "F",
     "E",
@@ -83,13 +83,16 @@ section-order = [
     "standard-library",
     "third-party",
     "first-party",
-    "local-folder"
+    "local-folder",
+]
+known-first-party  = [
+    "docnote",
 ]
 
 [tool.ruff.lint.pylint]
 max-args = 7
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests_py/**" = ["S101", "PLR2004", "N999"]
 
 [tool.refurb]

--- a/src_py/docnote/__init__.py
+++ b/src_py/docnote/__init__.py
@@ -1,25 +1,230 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
+from dataclasses import KW_ONLY
 from dataclasses import dataclass
 from dataclasses import field
+from dataclasses import fields as dc_fields
 from enum import Enum
+from functools import partial
+from typing import Annotated
+from typing import Any
+from typing import TypedDict
 
 __all__ = [
-    'ClcNote',
+    'DocnoteConfig',
+    'DocnoteGroup',
+    'Note',
+    'docnote',
 ]
 
 
 class MarkupLang(Enum):
-    CLEANCOPY = 'cleancopy'
-    MARKDOWN = 'markdown'
-    RST = 'rst'
+    CLEANCOPY = ('cleancopy', 'clc')
+    MARKDOWN = ('markdown', 'md')
+    RST = ('rst',)
 
 
 @dataclass(frozen=True, slots=True)
-class DocNote:
+class Note:
     value: str
-    lang: MarkupLang | None = field(kw_only=True)
+    _: KW_ONLY
+    config: DocnoteConfig | None = field(kw_only=True, default=None)
+
+
+class DocnoteConfigParams(TypedDict, total=False):
+    enforce_known_lang: bool
+    markup_lang: str | MarkupLang
+    include_in_docs: bool
+    parent_group_name: str
+    child_groups: Sequence[DocnoteGroup]
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class DocnoteConfig:
+    """``DocnoteConfig``s can be used for a variety of reasons:
+    ++  to control inference of the markup language when not explicitly
+        passed, and whether or not to enforce rules around markup langs
+    ++  to control whether an object should be included in the generated
+        documentation or not, overriding inference rules
+    ++  to define documentation sections (groups) that children can
+        assign themselves to
+    ++  to include themselves in a parent group
+
+    Note that most config parameters are stack-bound: children will
+    assume the values of their parents (unless the child defines its
+    own overriding config). Some, however -- like the ``child_groups``
+    setting -- are bound to only the exact object the config has been
+    "attached" to.
+
+    Configs can be attached:
+    ++  to a module, by assigning it to the ``DOCNOTE_CONFIG`` name
+    ++  to arbitrary names via ``Annotated``
+    ++  to classes and functions via the ``docnote`` decorator
+
+    **Note that module configs are inherited by submodules.** You can
+    use this, for example, to define a default markup language in your
+    entire project, by attaching a config to the toplevel
+    ``__init__.py``.
+    """
+    enforce_known_lang: Annotated[
+            bool | None,
+            ClcNote('''When ``True``, this will ensure that the current config
+                (and configs attached to its children) will enforce that the
+                ``markup_lang`` is included in your specified allowlist of
+                markup languages, **as determined by your docs generation
+                library.**
+
+                Note that the actual check **is not performed by docnote, and
+                must be performed by your docs generation library.**
+                ''')
+        ] = field(default=None, metadata={'docnote.stacked': True})
+    markup_lang: Annotated[
+            str | MarkupLang | None,
+            ClcNote('''When specified, this sets the markup language to use
+                for any ``Note`` instances on the attached object (and its
+                children) that don't explicitly declare a ``lang`` value.
+                ''')
+        ] = field(default=None, metadata={'docnote.stacked': True})
+    include_in_docs: Annotated[
+            bool | None,
+            ClcNote('''Whether or not to include the attached object (and its
+                children) in the generated documentation. By default
+                (``None``), this will be inferred based on python conventions:
+                names with a single underscore (or ``__mangled`` names) will
+                be excluded, and others included.
+
+                An explicit boolean value can be used to override this
+                behavior, forcing exclusion of otherwise-conventionally-public
+                objects, or inclusion of conventionally private ones.
+
+                Note that under the following situation:
+                ++  parent sets ``include_in_docs=False``
+                ++  child sets ``include_in_docs=True``
+                the end behavior is determined by the docs generation library.
+                ''')
+        ] = field(default=None, metadata={'docnote.stacked': True})
+    parent_group_name: Annotated[
+            str | None,
+            ClcNote('''This assigns the attached object to a group within its
+                parent by its name.
+
+                Note that docnote itself **does not validate the name** at
+                definition time; this is a deliberate choice to avoid library
+                consumers from paying an import-time penalty for projects
+                using docnotes.
+
+                You should instead rely upon your docs generation library for
+                validating these values, ideally as part of your CI/CD suite,
+                git hooks, etc.
+                ''')
+        ] = field(default=None, metadata={'docnote.stacked': False})
+    child_groups: Annotated[
+            Sequence[DocnoteGroup] | None,
+            ClcNote('''This defines both the groups that should be available
+                for immediate children to assign themselves to, as well as
+                their desired ordering in the final documentation.
+
+                **Note that this applies only to the immediate children of
+                the scope the config was assigned to.** For example, if the
+                config is assigned to a module, it will apply only to toplevel
+                members of the module (classes, functions, etc defined directly
+                as part of the module).
+                ''')
+        ] = field(default=None, metadata={'docnote.stacked': False})
+    metadata: Annotated[
+            dict[str, Any] | None,
+            ClcNote('''Arbitrary metadata may be included in the config as
+                an extension mechanism for docs generation libraries.
+
+                Whether or not a particular key is inherited by children of
+                the attached objects is up to the implementation of the
+                docs generation library defining the metadata key.
+                ''')
+        ] = field(default=None, metadata={'docnote.stacked': None})
+
+    def get_stackables(self) -> DocnoteConfigParams:
+        retval: DocnoteConfigParams = {}
+        for dc_field in dc_fields(self):
+            if dc_field.metadata.get('docnote.stacked'):
+                value = getattr(self, dc_field.name)
+                if value is not None:
+                    retval[dc_field.name] = value
+
+        return retval
+
+    def __post_init__(self):
+        """The vast majority of checks are done by the docs generation
+        library in order to avoid runtime consequences for libraries
+        that use docnote. However, the one thing we ^^do^^ actually
+        verify is that the group names are unique.
+        """
+        if self.child_groups is not None:
+            group_names = {
+                group.name for group in self.child_groups}
+            if len(group_names) != len(self.child_groups):
+                raise ValueError(
+                    'Cannot have duplicate docnote group names for a single '
+                    + 'attached object!')
+
+
+# We have this for two reasons: first, for backwards compatibility.
+# Second, because within the docnote library itself, we can't specify an
+# inference parameter via config, so we'd prefer just to be explicit
+# everywhere.
+ClcNote = partial(Note, config=DocnoteConfig(markup_lang=MarkupLang.CLEANCOPY))
+DOCNOTE_CONFIG_ATTR: Annotated[
+        str,
+        ClcNote('''Docs generation libraries should use this value to
+            get access to any configs attached to objects via the
+            ``docnote`` decorator.
+            ''')
+    ] = '_docnote_config'
 
 
 @dataclass(frozen=True, slots=True)
-class ClcNote:
-    value: str
-    lang: MarkupLang = MarkupLang.CLEANCOPY
+class DocnoteGroup:
+    name: Annotated[
+        str,
+        ClcNote('''The name of the ``DocnoteGroup`` is used by children to
+            assign themselves to the group.
+
+            It might also be used by an automatic docs generation library in
+            its description of the group.
+            ''')]
+    _: KW_ONLY
+    description: Annotated[
+            str | None,
+            ClcNote('''Groups may optionally include a description, which
+                may be used by your docs generation library.
+                ''')
+        ] = None
+    metadata: Annotated[
+            dict[str, Any] | None,
+            ClcNote('''Groups may optionally include metadata, which
+                may be used by your docs generation library.
+                ''')
+        ] = None
+
+
+def docnote[T](
+        config: DocnoteConfig
+        ) -> Callable[[T], T]:
+    """This decorator attaches a configuration to a decoratable object:
+
+    > Example usage
+    __embed__: 'code/python'
+        from docnote import DocnoteConfig
+        from docnote import docnote
+
+        @docnote(DocnoteConfig(include_in_docs=False))
+        def my_unconventional_private_function(): ...
+    """
+    return partial(_attach_config, config=config)
+
+
+def _attach_config[T](to_decorate: T, *, config: DocnoteConfig) -> T:
+    setattr(to_decorate, DOCNOTE_CONFIG_ATTR, config)
+    return to_decorate

--- a/src_py/docnote/__init__.py
+++ b/src_py/docnote/__init__.py
@@ -174,7 +174,10 @@ class DocnoteConfig:
 # Second, because within the docnote library itself, we can't specify an
 # inference parameter via config, so we'd prefer just to be explicit
 # everywhere.
-ClcNote = partial(Note, config=DocnoteConfig(markup_lang=MarkupLang.CLEANCOPY))
+ClcNote: Annotated[
+        Callable[[str], Note],
+        DocnoteConfig(include_in_docs=False)
+    ] = partial(Note, config=DocnoteConfig(markup_lang=MarkupLang.CLEANCOPY))
 DOCNOTE_CONFIG_ATTR: Annotated[
         str,
         ClcNote('''Docs generation libraries should use this value to

--- a/tests_py/docnote.test.py
+++ b/tests_py/docnote.test.py
@@ -1,8 +1,95 @@
+from typing import get_type_hints
+
+import pytest
+
+from docnote import DOCNOTE_CONFIG_ATTR
 from docnote import ClcNote
+from docnote import DocnoteConfig
+from docnote import DocnoteConfigParams
+from docnote import DocnoteGroup
+from docnote import MarkupLang
+from docnote import Note
+from docnote import docnote_config
 
 
-def test_clc_note():
-    """ClcNote instances must be constructable as expected.
-    This is about as close to a gimme as you can get.
-    """
-    assert ClcNote('Some doc note here')
+class TestDocnote:
+    def test_clc_note(self):
+        """ClcNote instances must be constructable as expected.
+        This is about as close to a gimme as you can get.
+        """
+        note = ClcNote('Some doc note here')
+        assert note.config is not None
+        assert note.config.markup_lang is MarkupLang.CLEANCOPY
+
+    def test_plain_note(self):
+        """Note instances must be constructable as expected.
+        """
+        note = Note('Some doc note here')
+        assert note.config is None
+
+    def test_decorator(self):
+        """The @docnote_config decorator must return the original
+        decoree with the DOCNOTE_CONFIG_ATTR added.
+        """
+        class TestClass:
+            pass
+
+        assert not hasattr(TestClass, DOCNOTE_CONFIG_ATTR)
+
+        config = DocnoteConfig()
+        retval = docnote_config(config)(TestClass)
+        assert retval is TestClass
+        assert hasattr(TestClass, DOCNOTE_CONFIG_ATTR)
+        assert getattr(TestClass, DOCNOTE_CONFIG_ATTR) is config
+
+    def test_docnote_group(self):
+        """Docnote groups must be creatable, assignable within a
+        config, and ordered within that group.
+        """
+        group1 = DocnoteGroup('group1')
+        group2 = DocnoteGroup('group2')
+        group3 = DocnoteGroup('group3')
+        group4 = DocnoteGroup('group4')
+
+        config = DocnoteConfig(child_groups=[group1, group2, group3, group4])
+        assert config.child_groups is not None
+        assert tuple(config.child_groups) == (group1, group2, group3, group4)
+
+    @pytest.mark.parametrize(
+        'before,expected_retval',
+        [
+            (
+                DocnoteConfig(enforce_known_lang=True),
+                {'enforce_known_lang': True}),
+            (
+                DocnoteConfig(
+                    enforce_known_lang=False,
+                    markup_lang='foo',),
+                {'enforce_known_lang': False, 'markup_lang': 'foo'}),
+            (
+                DocnoteConfig(),
+                {}),
+            (
+                DocnoteConfig(parent_group_name='foo'),
+                {}),
+            (
+                DocnoteConfig(
+                    enforce_known_lang=True,
+                    parent_group_name='foo'),
+                {'enforce_known_lang': True}),])
+    def test_get_stackables(self, before: DocnoteConfig, expected_retval):
+        assert before.get_stackables() == expected_retval
+
+    def test_config_params_matches_config(self):
+        """The DocnoteConfigParams typeddict must match the
+        DocnoteConfig.
+        """
+        params_hints = get_type_hints(DocnoteConfigParams)
+        config_hints = get_type_hints(DocnoteConfig)
+
+        assert set(params_hints) == set(config_hints)
+
+        for key, param_hint_value in params_hints.items():
+            config_hint_value = config_hints[key]
+
+            assert (param_hint_value | None) == config_hint_value

--- a/tests_py/docnote.test.py
+++ b/tests_py/docnote.test.py
@@ -9,7 +9,7 @@ from docnote import DocnoteConfigParams
 from docnote import DocnoteGroup
 from docnote import MarkupLang
 from docnote import Note
-from docnote import docnote_config
+from docnote import docnote
 
 
 class TestDocnote:
@@ -28,7 +28,7 @@ class TestDocnote:
         assert note.config is None
 
     def test_decorator(self):
-        """The @docnote_config decorator must return the original
+        """The @docnote decorator must return the original
         decoree with the DOCNOTE_CONFIG_ATTR added.
         """
         class TestClass:
@@ -37,7 +37,7 @@ class TestDocnote:
         assert not hasattr(TestClass, DOCNOTE_CONFIG_ATTR)
 
         config = DocnoteConfig()
-        retval = docnote_config(config)(TestClass)
+        retval = docnote(config)(TestClass)
         assert retval is TestClass
         assert hasattr(TestClass, DOCNOTE_CONFIG_ATTR)
         assert getattr(TestClass, DOCNOTE_CONFIG_ATTR) is config

--- a/uv.lock
+++ b/uv.lock
@@ -2,30 +2,12 @@ version = 1
 requires-python = ">=3.12.0"
 
 [[package]]
-name = "asttokens"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918 },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
-]
-
-[[package]]
-name = "decorator"
-version = "5.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190 },
 ]
 
 [[package]]
@@ -37,7 +19,6 @@ lint = [
     { name = "ruff" },
 ]
 repl = [
-    { name = "ipython" },
     { name = "wat-inspector" },
 ]
 test = [
@@ -48,20 +29,8 @@ test = [
 
 [package.metadata.requires-dev]
 lint = [{ name = "ruff", specifier = ">=0.3.3" }]
-repl = [
-    { name = "ipython", specifier = ">=8.8.0" },
-    { name = "wat-inspector", specifier = ">=0.3.2" },
-]
+repl = [{ name = "wat-inspector", specifier = ">=0.3.2" }]
 test = [{ name = "pytest", specifier = ">=8.1.1" }]
-
-[[package]]
-name = "executing"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702 },
-]
 
 [[package]]
 name = "iniconfig"
@@ -70,63 +39,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
-]
-
-[[package]]
-name = "ipython"
-version = "9.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/02/63a84444a7409b3c0acd1de9ffe524660e0e5d82ee473e78b45e5bfb64a4/ipython-9.2.0.tar.gz", hash = "sha256:62a9373dbc12f28f9feaf4700d052195bf89806279fc8ca11f3f54017d04751b", size = 4424394 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/ce/5e897ee51b7d26ab4e47e5105e7368d40ce6cfae2367acdf3165396d50be/ipython-9.2.0-py3-none-any.whl", hash = "sha256:fef5e33c4a1ae0759e0bba5917c9db4eb8c53fee917b6a526bd973e1ca5159f6", size = 604277 },
-]
-
-[[package]]
-name = "ipython-pygments-lexers"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074 },
-]
-
-[[package]]
-name = "jedi"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "parso" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278 },
-]
-
-[[package]]
-name = "matplotlib-inline"
-version = "0.1.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90", size = 8159 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca", size = 9899 },
 ]
 
 [[package]]
@@ -139,72 +51,12 @@ wheels = [
 ]
 
 [[package]]
-name = "parso"
-version = "0.8.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650 },
-]
-
-[[package]]
-name = "pexpect"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ptyprocess" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772 },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
-]
-
-[[package]]
-name = "prompt-toolkit"
-version = "3.0.51"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/6e/9d084c929dfe9e3bfe0c6a47e31f78a25c54627d64a66e884a8bf5474f1c/prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed", size = 428940 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/4f/5249960887b1fbe561d9ff265496d170b55a735b76724f10ef19f9e40716/prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07", size = 387810 },
-]
-
-[[package]]
-name = "ptyprocess"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993 },
-]
-
-[[package]]
-name = "pure-eval"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842 },
-]
-
-[[package]]
-name = "pygments"
-version = "2.19.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]
@@ -248,42 +100,10 @@ wheels = [
 ]
 
 [[package]]
-name = "stack-data"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asttokens" },
-    { name = "executing" },
-    { name = "pure-eval" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
-]
-
-[[package]]
-name = "traitlets"
-version = "5.14.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359 },
-]
-
-[[package]]
 name = "wat-inspector"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/71/ed/463950964282fb8e40d363baeba3b2852b3dba3c1acea538e553959fa721/wat_inspector-0.4.3.tar.gz", hash = "sha256:1c47c4943eec631d7d6412f4e6a225fa29c21db30143728d6bbb6f873790ec77", size = 23023 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/d0/05abf7dae933697d882ff7e410afb9b02e32640cc770cad2a63428e14f90/wat_inspector-0.4.3-py3-none-any.whl", hash = "sha256:b739b8779ccd729503caa8912cf1d1c59eba3762707f40ed6dbb92434af3bd1f", size = 15042 },
-]
-
-[[package]]
-name = "wcwidth"
-version = "0.2.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
 ]


### PR DESCRIPTION
# Summary

Things have been working fine for simple ``ClcNote`` declarations. The problem is, as soon as you start needing to do more complicated things -- for example, overriding whether or not a particular method should be surfaced in the API docs -- you're just completely out-of-luck. Additionally, since most notes in the same module are going to use the same markup language, needing to explicitly specify that language for each and every note starts to get a bit cumbersome.

This PR addresses all of the above by moving to an explicit config declaration approach.

# Testing

Added some unit tests. I'd say this got a bit overkill, but I actually discovered a bug with them, even with how simple the code is. 🤷 

# Details

+ Updated docs (README.clc) with the new approach to things
+ Added a bunch of docnotes within the library itself, soon to be used for documenting the library itself (yay dogfood!)
+ added ``@docnote``
+ changed notes to ``Note`` class. Kept ``ClcNote`` for backwards compat, though it should be considered deprecated and I marked it to exclude from the docs
+ Added ``DocnoteConfig`` and ``DocnoteGroup``
+ Slightly reworked the ``MarkupLang`` declaration to make it easier for consuming code to have custom markup languages