### PR TITLE
Add documentation of module-level config attr; fix stacking for include_in_docs

### DIFF
--- a/README.clc
+++ b/README.clc
@@ -5,9 +5,10 @@ This is a very, very lightweight library that provides a unified API for
 defining documentation notes within python source code as values passed via
 ``Annotated``.
 
-On its own, this isn't very useful, but in combination with a docs-generation
-library that is aware of them (for example, ``docnote_build``), it can be very
-powerful.
+On its own, this isn't very useful, but in combination with a docs-extraction
+library that is aware of them (for example, ``docnote_extract``), and then to
+a docs-generation library that knows how to make use of the extracted docs
+(for example, ``cleancopywriter``) it can be very powerful.
 
 This is distributed as a separate package because it must, by definition, be
 included as a production dependency in any packages that make use of it, and

--- a/src_py/docnote/__init__.py
+++ b/src_py/docnote/__init__.py
@@ -10,6 +10,8 @@ from enum import Enum
 from functools import partial
 from typing import Annotated
 from typing import Any
+from typing import Final
+from typing import LiteralString
 from typing import TypedDict
 
 __all__ = [
@@ -124,9 +126,9 @@ class DocnoteConfig:
                 Note that under the following situation:
                 ++  parent sets ``include_in_docs=False``
                 ++  child sets ``include_in_docs=True``
-                the end behavior is determined by the docs generation library.
+                the end behavior is determined by the docs extraction library.
                 ''')
-        ] = field(default=None, metadata={'docnote.stacked': True})
+        ] = field(default=None, metadata={'docnote.stacked': False})
 
     parent_group_name: Annotated[
             str | None,
@@ -226,12 +228,19 @@ ClcNote: Annotated[
         DocnoteConfig(include_in_docs=False)
     ] = partial(Note, config=DocnoteConfig(markup_lang=MarkupLang.CLEANCOPY))
 DOCNOTE_CONFIG_ATTR: Annotated[
-        str,
+        Final[LiteralString],
         Note('''Docs generation libraries should use this value to
             get access to any configs attached to objects via the
             ``docnote`` decorator.
             ''')
     ] = '_docnote_config'
+DOCNOTE_CONFIG_ATTR_FOR_MODULES: Annotated[
+        Final[LiteralString],
+        Note('''Modules documented via docnote can defined a module-level
+            ``DocnoteConfig`` at this attribute to customize the behavior
+            of the module itself.
+            ''')
+    ] = 'DOCNOTE_CONFIG'
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
# Summary

This is a drive-by cleanup that fixes one minor issue encountered during docnote_extract development, and one minor enhancement that serves primarily to document what attribute to put module-level configs on. Specifically:

+ Stacking for ``include_in_docs`` on the config was corrected (was ``True``, now ``False``)
+ added ``DOCNOTE_CONFIG_ATTR_FOR_MODULES`` containing the module-level config attr
+ updated ``DOCNOTE_CONFIG_ATTR`` to use ``Final[LiteralString]`` instead of just ``str``