### PR TITLE
Add ``as_nontotal_dict`` to configs

### DIFF
--- a/src_py/docnote/__init__.py
+++ b/src_py/docnote/__init__.py
@@ -197,12 +197,29 @@ class DocnoteConfig:
         ] = field(default=None, metadata={'docnote.stacked': None})
 
     def get_stackables(self) -> DocnoteConfigParams:
+        """Gets all of the **non-None** params that are also marked as
+        being stackable. Note that unlike dataclasses.asdict, this does
+        not create any copies of the underlying objects.
+        """
         retval: DocnoteConfigParams = {}
         for dc_field in dc_fields(self):
             if dc_field.metadata.get('docnote.stacked'):
                 value = getattr(self, dc_field.name)
                 if value is not None:
                     retval[dc_field.name] = value
+
+        return retval
+
+    def as_nontotal_dict(self) -> DocnoteConfigParams:
+        """Gets all of the **non-None** params, regardless of whether
+        they are stacked or not. Note that unlike dataclasses.asdict,
+        this does not create any copies of the underlying objects.
+        """
+        retval: DocnoteConfigParams = {}
+        for dc_field in dc_fields(self):
+            value = getattr(self, dc_field.name)
+            if value is not None:
+                retval[dc_field.name] = value
 
         return retval
 

--- a/tests_py/docnote.test.py
+++ b/tests_py/docnote.test.py
@@ -80,6 +80,31 @@ class TestDocnote:
     def test_get_stackables(self, before: DocnoteConfig, expected_retval):
         assert before.get_stackables() == expected_retval
 
+    @pytest.mark.parametrize(
+        'before,expected_retval',
+        [
+            (
+                DocnoteConfig(enforce_known_lang=True),
+                {'enforce_known_lang': True}),
+            (
+                DocnoteConfig(
+                    enforce_known_lang=False,
+                    markup_lang='foo',),
+                {'enforce_known_lang': False, 'markup_lang': 'foo'}),
+            (
+                DocnoteConfig(),
+                {}),
+            (
+                DocnoteConfig(parent_group_name='foo'),
+                {'parent_group_name': 'foo'}),
+            (
+                DocnoteConfig(
+                    enforce_known_lang=True,
+                    parent_group_name='foo'),
+                {'enforce_known_lang': True, 'parent_group_name': 'foo'}),])
+    def test_as_nontotal_dict(self, before: DocnoteConfig, expected_retval):
+        assert before.as_nontotal_dict() == expected_retval
+
     def test_config_params_matches_config(self):
         """The DocnoteConfigParams typeddict must match the
         DocnoteConfig.


### PR DESCRIPTION
# Summary

While working on config inheritance within docnote_extract, I needed a way to get **all** non-None config values (but only the non-None ones). This PR adds them, under the ``as_nontotal_dict`` method.

# Testing

Also added a parameterized unit test for it.